### PR TITLE
Fix #42 Bug with Install Instructions / Requirements

### DIFF
--- a/fuji_server/data/software_file.json
+++ b/fuji_server/data/software_file.json
@@ -24,7 +24,8 @@
     ],
     "parse": "file_name",
     "pattern": [
-      "requirements\\.txt"
+      "requirements\\.txt",
+      "pyproject\\.toml"
     ]
   },
   "docs_directory": {

--- a/fuji_server/evaluators/fair_evaluator_requirements.py
+++ b/fuji_server/evaluators/fair_evaluator_requirements.py
@@ -58,7 +58,7 @@ class FAIREvaluatorRequirements(FAIREvaluator):
             )
         for d in values:
             if isinstance(d, bytes):
-                d = d.decode("utf-8")
+                d = d.decode("utf-8", errors="replace")
             if isinstance(d, str):
                 if key in d.lower():
                     return True
@@ -88,13 +88,17 @@ class FAIREvaluatorRequirements(FAIREvaluator):
                 content = self.fuji.github_data.get(location)
                 if content is not None:
                     if isinstance(content, bytes):
-                        content = content.decode("utf-8")
+                        content = content.decode("utf-8", errors="replace")
                     if isinstance(content, str):
                         if k in content.lower():
                             hit_dict[k] = True  # found keyword in location
-                            keys_to_check.remove(k)  # stop looking, have found something for this key
                     else:
                         hit_dict[k] = self.nestedDataContainsKeyword(content, k)
+                if hit_dict[k] is True:
+                    keys_to_check.remove(k)  # Need to also stop looking
+                    self.logger.info(
+                        f"{self.metric_identifier} : Found {k} in {location}"
+                    )  # Info message for specific keys
         return hit_dict
 
     def testInstructions(self):

--- a/fuji_server/yaml/metrics_v0.7_software.yaml
+++ b/fuji_server/yaml/metrics_v0.7_software.yaml
@@ -356,6 +356,7 @@ metrics:
       required:
         dependency_file:
         - requirements.txt
+        - pyproject.toml
     - target: https://f-uji.net/vocab/metadata/standards
       modality: all
       required:
@@ -367,7 +368,7 @@ metrics:
         - deploy
   created_by: FAIR4RS
   date_created: 2024-01-18
-  date_updated: 2024-01-18
+  date_updated: 2024-08-28
   version: 0.1
   total_score: 2
 - metric_identifier: FRSM-14-R1


### PR DESCRIPTION
Fixes #42 

## Description

An issue was found with FRSM-13-R1-1, it was identified that when a nested data type was checked they key was not removed from the check key list, causing the loop to continue checking and having the potential to override the found key. Addionally it was found that non errors while decoding bytes to string was set to default ("strict") this may cause issues with non utf-8 parsable characters. Subsequently this was changed to "replace".

Additionally pyproject.toml was added to the dependencies as this is a recognised python dependencies file (enhancing FRSM-13-R1-2)

Related issue: #42 

## Motivation and context
Fixes issue which prevents FRSM-13-R1-1/2 from passing

## How has this been tested?
Tested using the swagger openAPI using the repo mention in the bug as well as repos which passed and failed this check including https://github.com/FAIRDataPipeline/pyDataPipeline

No additional tests where written following the testing framework already in place.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
- [N/A] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- This pull request template is adapted from:
<!--- "open-source-templates", https://github.com/TalAter/open-source-templates (MIT License). --->
<!--- "amazing-github-template", https://github.com/dec0dOS/amazing-github-template (MIT License). --->
