### PR TITLE
#8 FRSM-07-F3 software metadata include identifier

### DIFF
--- a/fuji_server/data/software_file.json
+++ b/fuji_server/data/software_file.json
@@ -65,5 +65,14 @@
     "pattern": [
       "pom\\.xml"
     ]
+  },
+  "CITATION": {
+    "category": [
+      "citation"
+    ],
+    "parse": "full",
+    "pattern": [
+      "CITATION\\.cff"
+    ]
   }
 }

--- a/fuji_server/yaml/metrics_v0.7_software.yaml
+++ b/fuji_server/yaml/metrics_v0.7_software.yaml
@@ -186,7 +186,7 @@ metrics:
   metric_tests:
   - metric_test_identifier: FRSM-07-F3-1
     metric_test_name: Does the software include an identifier in the README or citation file?
-    metric_test_score: 1
+    metric_test_score: 2
     metric_test_maturity: 1
     metric_test_requirements:
       - target: https://f-uji.net/vocab/metadata/standards
@@ -197,13 +197,13 @@ metrics:
             - CITATION
   - metric_test_identifier: FRSM-07-F3-2
     metric_test_name: Does the identifier resolve to the same instance of the software?
-    metric_test_score: 1
+    metric_test_score: 2
     metric_test_maturity: 2
   created_by: FAIR4RS
   date_created: 2024-01-18
   date_updated: 2024-01-18
   version: 0.1
-  total_score: 2
+  total_score: 4
 - metric_identifier: FRSM-08-F4
   metric_number: 8
   metric_short_name: Persistent Metadata

--- a/fuji_server/yaml/metrics_v0.7_software.yaml
+++ b/fuji_server/yaml/metrics_v0.7_software.yaml
@@ -188,6 +188,13 @@ metrics:
     metric_test_name: Does the software include an identifier in the README or citation file?
     metric_test_score: 1
     metric_test_maturity: 1
+    metric_test_requirements:
+      - target: https://f-uji.net/vocab/metadata/standards
+        modality: any
+        required:
+          location:
+            - README
+            - CITATION
   - metric_test_identifier: FRSM-07-F3-2
     metric_test_name: Does the identifier resolve to the same instance of the software?
     metric_test_score: 1

--- a/fuji_server/yaml/metrics_v0.7_software_cessda.yaml
+++ b/fuji_server/yaml/metrics_v0.7_software_cessda.yaml
@@ -176,10 +176,18 @@ metrics:
     metric_test_name: The README file includes the DOI that represents all versions in Zenodo.
     metric_test_score: 1
     metric_test_maturity: 1
+    modality: any
+    required:
+      location:
+        - README
   - metric_test_identifier: FRSM-07-F3-CESSDA-2
     metric_test_name: The CITATION.cff file included in the root of the repository includes the appropriate DOI for the corresponding software release in Zenodo.
     metric_test_score: 1
     metric_test_maturity: 2
+    modality: any
+    required:
+      location:
+        - CITATION
   created_by: FAIR4RS
   date_created: 2024-01-18
   date_updated: 2024-01-18


### PR DESCRIPTION

## Description
Implementation of the metric FRSM-07-F3: Does the software metadata include the identifier of the software it describes?
The metric tests include:
- **FRSM-07-F3-1**
    - Does the software include an identifier in the README or citation file?
    - def testZenodoDoiInReadme(self): 
    Checks if the README file contains a zenodo DOI 
    - def testZenodoDoiInCitationFile(self):
    Checks if the CITATION file contains a zenodo DOI
    - Final score is 2 that adds +1 when DOI is found in README or CITATION file
- **FRSM-07-F3-2**
    - Does the identifier resolve to the same instance of the software?
    - Get zenodo metadata with zenodo api calls for given found DOIs 
    - def compareResolvedUrlIdentifiers(self):
    Checks if the found related_identifiers from README or CITATION file resolve to the same instance of the software
    - def testResolvesSameContent(self, location, pid_url):
    Checks if a given DOI (pid_url) resolves to the same instance of the software 
    - def resolveRelatedIdentifiersFromDoi(self, doi_url):
    Checks if zenodo metadata from given DOI fetched from zenodo api contains related_identifiers with GitHub link
    - Final score is 2 with 2 beeing both README and CITATION contain the same identifier that resolves to the same instance of the software and with 1 beeing only one of those contains the identifier that resolves to the same instance of the software
   
Related issue: #8

## Motivation and context
This implements the metric FRSM-07-F3 which is essential for the usage of fuji

## How has this been tested?
Tested with multiple urls and docker environment. My code is not affecting other metrics. 

## Screenshots (if appropriate)
Metric FRSM-07-F3 with url: https://github.com/pangaea-data-publisher/fuji
![screenshot F3](https://github.com/user-attachments/assets/4f1fb774-53eb-4952-bb85-01f9434d40e7)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist
- [x] I have read the [contributor guide](https://github.com/pangaea-data-publisher/fuji/blob/master/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
