### PR TITLE
Add test for FRSM-01-F1 metric to search codemeta.json file at the project root

### DIFF
--- a/fuji_server/data/software_file.json
+++ b/fuji_server/data/software_file.json
@@ -65,5 +65,14 @@
     "pattern": [
       "pom\\.xml"
     ]
+  },
+  "CodeMeta": {
+    "category": [
+      "documentation"
+    ],
+    "parse": "full",
+    "pattern": [
+      "codemeta\\.json"
+    ]
   }
 }

--- a/fuji_server/yaml/metrics_v0.7_software.yaml
+++ b/fuji_server/yaml/metrics_v0.7_software.yaml
@@ -23,14 +23,18 @@ metrics:
   test_scoring_mechanism: cumulative
   metric_tests:
   - metric_test_identifier: FRSM-01-F1-1
-    metric_test_name: The software has a human and machine-readable unique identifier that is resolvable to a machine-readable landing page and follows a defined unique identifier syntax.
+    metric_test_name: The software has a CodeMeta file located at project root.
     metric_test_score: 1
     metric_test_maturity: 1
   - metric_test_identifier: FRSM-01-F1-2
+    metric_test_name: The software has a human and machine-readable unique identifier that is resolvable to a machine-readable landing page and follows a defined unique identifier syntax.
+    metric_test_score: 1
+    metric_test_maturity: 1
+  - metric_test_identifier: FRSM-01-F1-3
     metric_test_name: The identifier uses an identifier scheme that guarantees globally uniqueness and persistence.
     metric_test_score: 1
     metric_test_maturity: 2
-  - metric_test_identifier: FRSM-01-F1-3
+  - metric_test_identifier: FRSM-01-F1-4
     metric_test_name: The identifier scheme is commonly used in the domain.
     metric_test_score: 1
     metric_test_maturity: 3


### PR DESCRIPTION
## Description

This PR add a basic check to test if `codemeta.json` file exists at the project root.

Related issue: #1

## How has this been tested?

Run the FUJI endpoint `POST /evaluate` with the request body below.
```json
{
  "object_identifier": "https://github.com/scivision/pyfindfiles",
  "test_debug": true,
  "metadata_service_endpoint": "http://ws.pangaea.de/oai/provider",
  "metadata_service_type": "oai_pmh",
  "use_datacite": true,
  "use_github": true,
  "metric_version": "metrics_v0.7_software"
}
```

The FUJI response must returns **pass** for the test **FRSM-01-F1-1** (_The software has a CodeMeta file located at project root_).

The full JSON response for the request to the FUJI endpoint `POST /evaluate` is copied below.

```json
{
  "test_id": "39d57ffbc3b1b8134434f41f2a22cdceaf3d9175",
  "request": {
    "object_identifier": "https://github.com/scivision/pyfindfiles",
    "test_debug": true,
    "metadata_service_endpoint": "http://ws.pangaea.de/oai/provider",
    "metadata_service_type": "oai_pmh",
    "use_datacite": true,
    "use_github": true,
    "metric_version": "metrics_v0.7_software"
  },
  "resolved_url": "https://github.com/scivision/pyfindfiles",
  "start_timestamp": "2024-09-28T17:45:03Z",
  "end_timestamp": "2024-09-28T17:45:13Z",
  "metric_specification": "https://doi.org/10.5281/zenodo.6461229",
  "metric_version": "metrics_v0.7_software",
  "software_version": "3.2.0",
  "total_metrics": 17,
  "summary": {
    "score_earned": {
      "A": 0,
      "F": 0,
      "I": 0,
      "R": 5,
      "A1": 0,
      "F1": 0,
      "F1.1": 0,
      "F1.2": 0,
      "F2": 0,
      "F3": 0,
      "F4": 0,
      "I1": 0,
      "I2": 0,
      "R1": 1,
      "R1.1": 4,
      "R1.2": 0,
      "FAIR": 5
    },
    "score_total": {
      "A": 2,
      "F": 20,
      "I": 7,
      "R": 16,
      "A1": 2,
      "F1": 3,
      "F1.1": 3,
      "F1.2": 3,
      "F2": 6,
      "F3": 2,
      "F4": 3,
      "I1": 6,
      "I2": 1,
      "R1": 8,
      "R1.1": 5,
      "R1.2": 3,
      "FAIR": 45
    },
    "score_percent": {
      "A": 0,
      "F": 0,
      "I": 0,
      "R": 31.25,
      "A1": 0,
      "F1": 0,
      "F1.1": 0,
      "F1.2": 0,
      "F2": 0,
      "F3": 0,
      "F4": 0,
      "I1": 0,
      "I2": 0,
      "R1": 12.5,
      "R1.1": 80,
      "R1.2": 0,
      "FAIR": 11.11
    },
    "status_total": {
      "A1": 1,
      "F1": 1,
      "F1.1": 1,
      "F1.2": 1,
      "F2": 2,
      "F3": 1,
      "F4": 1,
      "I1": 2,
      "I2": 1,
      "R1": 3,
      "R1.1": 2,
      "R1.2": 1,
      "A": 1,
      "F": 7,
      "I": 3,
      "R": 6,
      "FAIR": 17
    },
    "status_passed": {
      "A1": 0,
      "F1": 0,
      "F1.1": 0,
      "F1.2": 0,
      "F2": 0,
      "F3": 0,
      "F4": 0,
      "I1": 0,
      "I2": 0,
      "R1": 1,
      "R1.1": 2,
      "R1.2": 0,
      "A": 0,
      "F": 0,
      "I": 0,
      "R": 3,
      "FAIR": 3
    },
    "maturity": {
      "A": 0,
      "F": 1,
      "I": 0,
      "R": 1,
      "A1": 0,
      "F1": 1,
      "F1.1": 0,
      "F1.2": 0,
      "F2": 0,
      "F3": 0,
      "F4": 0,
      "I1": 0,
      "I2": 0,
      "R1": 1,
      "R1.1": 3,
      "R1.2": 0,
      "FAIR": 1
    }
  },
  "results": [
    {
      "id": 1,
      "metric_identifier": "FRSM-01-F1",
      "metric_name": "Does the software have a globally unique and persistent identifier?",
      "metric_tests": {
        "FRSM-01-F1-1": {
          "metric_test_name": "The software has a CodeMeta file located at project root.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 1,
          "metric_test_status": "pass"
        },
        "FRSM-01-F1-2": {
          "metric_test_name": "The software has a human and machine-readable unique identifier that is resolvable to a machine-readable landing page and follows a defined unique identifier syntax.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-01-F1-3": {
          "metric_test_name": "The identifier uses an identifier scheme that guarantees globally uniqueness and persistence.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-01-F1-4": {
          "metric_test_name": "The identifier scheme is commonly used in the domain.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 1,
      "output": {},
      "test_debug": [
        "SUCCESS: Found CodeMeta file codemeta.json at repository root (FRSM-01-F1-1).",
        "WARNING: Test for unique identifier is not implemented.",
        "WARNING: Test for identifier scheme is not implemented.",
        "WARNING: Test for domain use of identifier scheme is not implemented.",
        "WARNING: Failed to check the software identifier."
      ]
    },
    {
      "id": 2,
      "metric_identifier": "FRSM-02-F1.1",
      "metric_name": "Do the different components of the software have their own identifiers?",
      "metric_tests": {
        "FRSM-02-F1.1-1": {
          "metric_test_name": "Where the 'software' consists of multiple distinct components, each component has a distinct identifier.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-02-F1.1-2": {
          "metric_test_name": "The relationship between components is embodied in the identifier metadata.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-02-F1.1-3": {
          "metric_test_name": "Every component to granularity level GL3 (module) has its own unique identifier.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for distinct identifiers is not implemented.",
        "WARNING: Test for identifier metadata is not implemented.",
        "WARNING: Test for GL3 (module) identifiers is not implemented.",
        "WARNING: Failed to check the software component identifiers."
      ]
    },
    {
      "id": 3,
      "metric_identifier": "FRSM-03-F1.2",
      "metric_name": "Does each version of the software have a unique identifier?",
      "metric_tests": {
        "FRSM-03-F1.2-1": {
          "metric_test_name": "Each version of the software has a different identifier.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-03-F1.2-2": {
          "metric_test_name": "Relations between the versions are included in the identifier metadata.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-03-F1.2-3": {
          "metric_test_name": "The version number is included in the identifier metadata.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for distinct identifiers is not implemented.",
        "WARNING: Test for identifier metadata is not implemented.",
        "WARNING: Test for version number in identifier is not implemented.",
        "WARNING: Failed to check the software version identifier."
      ]
    },
    {
      "id": 4,
      "metric_identifier": "FRSM-04-F2",
      "metric_name": "Does the software include descriptive metadata which helps define its purpose?",
      "metric_tests": {
        "FRSM-04-F2-1": {
          "metric_test_name": "The software includes a README or other file which includes the software title and description.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-04-F2-2": {
          "metric_test_name": "The software includes other descriptive metadata such as domain, funder, programming language, date created, and keywords.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-04-F2-3": {
          "metric_test_name": "The metadata is contained in a format such as CodeMeta or ProjectObjectModel that enables full machine actionability.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {
        "core_metadata_status": "insufficient metadata",
        "core_metadata_found": {
          "summary": "Concurrently find files containing text, or project language with codemeta.json - scivision/pyfindfiles"
        },
        "core_metadata_source": [
          [
            "MICRODATA_EMBEDDED",
            "microdata_rdfa"
          ],
          [
            "DUBLINCORE_EMBEDDED",
            "html_embedding"
          ],
          [
            "OPENGRAPH_EMBEDDED",
            "html_embedding"
          ]
        ]
      },
      "test_debug": [
        "INFO: Testing if any metadata has been made available via common web standards",
        "WARNING: Test for descriptive metadata is not implemented for FRSM.",
        "WARNING: Not all required core descriptive metadata elements exist, missing -: ['creator', 'keywords', 'object_identifier', 'publication_date', 'publisher', 'object_type', 'title']",
        "WARNING: Test for minimum metadata is not implemented.",
        "WARNING: Test for metadata format is not implemented."
      ]
    },
    {
      "id": 5,
      "metric_identifier": "FRSM-05-R1",
      "metric_name": "Does the software include development metadata which helps define its status?",
      "metric_tests": {
        "FRSM-05-R1-1": {
          "metric_test_name": "The software includes metadata for contact or support in the README or other intrinsic metadata file according to community standards.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-05-R1-2": {
          "metric_test_name": "The software includes metadata for development status, links to documentation.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-05-R1-3": {
          "metric_test_name": "The metadata is contained in a format such as CodeMeta or ProjectObjectModel that enables full machine-actionability.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for contact information is not implemented.",
        "WARNING: Test for development status in metadata is not implemented.",
        "WARNING: Test for metadata format is not implemented.",
        "WARNING: Failed to check the software development metadata."
      ]
    },
    {
      "id": 6,
      "metric_identifier": "FRSM-06-F2",
      "metric_name": "Does the software include metadata about the contributors and their roles?",
      "metric_tests": {
        "FRSM-06-F2-1": {
          "metric_test_name": "The software includes metadata about the contributors.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-06-F2-2": {
          "metric_test_name": "The software includes citation metadata that includes all contributors and their roles. This includes ORCIDs when contributors have them.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-06-F2-3": {
          "metric_test_name": "Does the citation metadata include the proportional credit attributed to each contributor?",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {
        "provenance_metadata_included": {
          "is_available": false,
          "provenance_metadata": []
        },
        "structured_provenance_available": null
      },
      "test_debug": [
        "WARNING: Test for descriptive metadata is not implemented for FRSM.",
        "INFO: Check if provenance information is available in descriptive metadata",
        "INFO: Check if provenance information is available in metadata about related resources",
        "WARNING: No provenance information found in metadata about related resources",
        "WARNING: Test for citation metadata is not implemented.",
        "WARNING: Test for proportional credit in citation metadata is not implemented."
      ]
    },
    {
      "id": 7,
      "metric_identifier": "FRSM-07-F3",
      "metric_name": "Does the software metadata include the identifier for the software?",
      "metric_tests": {
        "FRSM-07-F3-1": {
          "metric_test_name": "Does the software include an identifier in the README or citation file?",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-07-F3-2": {
          "metric_test_name": "Does the identifier resolve to the same instance of the software?",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 2
      },
      "maturity": 0,
      "output": {
        "object_identifier_included": null,
        "object_content_identifier_included": []
      },
      "test_debug": [
        "WARNING: Test for identifier resolve target is not implemented.",
        "WARNING: Valid data (content) identifier missing."
      ]
    },
    {
      "id": 8,
      "metric_identifier": "FRSM-08-F4",
      "metric_name": "Does the software have a publicly available, openly accessible and persistent metadata record?",
      "metric_tests": {
        "FRSM-08-F4-1": {
          "metric_test_name": "A metadata record for the software is present on an infrastructure that guarantees persistence.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-08-F4-2": {
          "metric_test_name": "The persistent metadata record is available through public search engines. The metadata has a globally unique and persistent identifier.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-08-F4-3": {
          "metric_test_name": "The persistent metadata record is available through multiple, cross-referenced infrastructures.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": [],
      "test_debug": [
        "WARNING: Test for descriptive metadata is not implemented for FRSM.",
        "WARNING: Test for availability through public search engine is not implemented.",
        "WARNING: Test for availability through multiple, cross-referenced infrastructures is not implemented."
      ]
    },
    {
      "id": 9,
      "metric_identifier": "FRSM-09-A1",
      "metric_name": "Is the software developed in a code repository / forge that uses standard communications protocols?",
      "metric_tests": {
        "FRSM-09-A1-1": {
          "metric_test_name": "The code repository / forge can be accessed using the identifier via a standardised protocol.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-09-A1-2": {
          "metric_test_name": "If authentication or authorisation are required, these are supported by the communication protocols and the repository / forge.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 2
      },
      "maturity": 0,
      "output": {
        "standard_data_protocol": {}
      },
      "test_debug": [
        "WARNING: Test for standard protocol is not implemented for FRSM.",
        "WARNING: Skipping protocol test for data since NO content (data) identifier is given in metadata"
      ]
    },
    {
      "id": 10,
      "metric_identifier": "FRSM-10-I1",
      "metric_name": "Are the formats used by the data consumed or produced by the software open and a reference provided to the format?",
      "metric_tests": {
        "FRSM-10-I1-1": {
          "metric_test_name": "The documentation describes the data formats used.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-10-I1-2": {
          "metric_test_name": "The data formats used are open.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-10-I1-3": {
          "metric_test_name": "A reference to the schema is provided.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": [],
      "test_debug": [
        "WARNING: Test for documentation abouut data formats is not implemented.",
        "WARNING: Test for openness of data formats is not implemented.",
        "WARNING: Test for presence of schema reference is not implemented.",
        "WARNING: Could not perform file format checks as data content identifier(s) unavailable/inaccesible"
      ]
    },
    {
      "id": 11,
      "metric_identifier": "FRSM-11-I1",
      "metric_name": "Does the software use open APIs that support machine-readable interface definition?",
      "metric_tests": {
        "FRSM-11-I1-1": {
          "metric_test_name": "The software provides documented APIs.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-11-I1-2": {
          "metric_test_name": "The APIs are open (freely accessible).",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-11-I1-3": {
          "metric_test_name": "The APIs include a machine-readable interface definition.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for documented API is not implemented.",
        "WARNING: Test for openness of API is not implemented.",
        "WARNING: Test for machine-readable interface definition is not implemented.",
        "WARNING: Failed to check the software API."
      ]
    },
    {
      "id": 12,
      "metric_identifier": "FRSM-12-I2",
      "metric_name": "Does the software provide references to other objects that support its use?",
      "metric_tests": {
        "FRSM-12-I2-1": {
          "metric_test_name": "The software metadata includes machine-readable references to articles describing the software, articles demonstrating use of the software, or to the data it uses.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 1
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "INFO: No debug messages received"
      ]
    },
    {
      "id": 13,
      "metric_identifier": "FRSM-13-R1",
      "metric_name": "Does the software describe what is required to use it?",
      "metric_tests": {
        "FRSM-13-R1-1": {
          "metric_test_name": "The software has build, installation and/or execution instructions.",
          "metric_test_requirements": [
            {
              "modality": "any",
              "required": {
                "location": [
                  "README",
                  "docs_directory",
                  "wiki"
                ],
                "keywords": [
                  "build",
                  "install",
                  "run"
                ]
              },
              "tested_on": null,
              "comment": null,
              "target": "https://f-uji.net/vocab/metadata/standards"
            }
          ],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 1,
          "metric_test_status": "pass"
        },
        "FRSM-13-R1-2": {
          "metric_test_name": "Dependencies are provided in a machine-readable format and the building and installation of the software is automated.",
          "metric_test_requirements": [
            {
              "modality": "any",
              "required": {
                "dependency_file": [
                  "requirements.txt"
                ]
              },
              "tested_on": null,
              "comment": null,
              "target": "https://f-uji.net/vocab/metadata/standards"
            },
            {
              "modality": "all",
              "required": {
                "automation_file": [
                  "Jenkinsfile",
                  "github_actions"
                ],
                "automation_keywords": [
                  "build",
                  "deploy"
                ]
              },
              "tested_on": null,
              "comment": null,
              "target": "https://f-uji.net/vocab/metadata/standards"
            }
          ],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "pass",
      "score": {
        "earned": 1,
        "total": 2
      },
      "maturity": 1,
      "output": {},
      "test_debug": [
        "INFO: Looking for any keywords ['build', 'install', 'run'] in ['README', 'docs_directory', 'wiki'] (FRSM-13-R1-1).",
        "SUCCESS: Found required keywords (FRSM-13-R1-1).",
        "INFO: Checking presence of any of ['requirements.txt'] (FRSM-13-R1-2).",
        "INFO: Looking for all keywords ['build', 'deploy'] in ['Jenkinsfile', 'github_actions'] (FRSM-13-R1-2).",
        "WARNING: Did not find any of ['requirements.txt'] (FRSM-13-R1-2).",
        "WARNING: Did not find all keywords ['build', 'deploy'] in ['Jenkinsfile', 'github_actions'] (FRSM-13-R1-2)."
      ]
    },
    {
      "id": 14,
      "metric_identifier": "FRSM-14-R1",
      "metric_name": "Does the software come with test cases to demonstrate it is working?",
      "metric_tests": {
        "FRSM-14-R1-1": {
          "metric_test_name": "Tests and data are provided to check that the software is operating as expected.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-14-R1-2": {
          "metric_test_name": "Automated unit and system tests are provided.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-14-R1-3": {
          "metric_test_name": "Code coverage / test coverage is reported.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for presence of tests and test data is not implemented.",
        "WARNING: Test for Automated unit and system tests is not implemented.",
        "WARNING: Test for code coverage is not implemented.",
        "WARNING: Failed to check the software version identifier."
      ]
    },
    {
      "id": 15,
      "metric_identifier": "FRSM-15-R1.1",
      "metric_name": "The software source code includes licensing information for the software and any bundled external software.",
      "metric_tests": {
        "FRSM-15-R1.1-1": {
          "metric_test_name": "License file is included.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 1,
          "metric_test_status": "pass"
        },
        "FRSM-15-R1.1-2": {
          "metric_test_name": "The source code includes licensing information for all components bundled with that software.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-15-R1.1-3": {
          "metric_test_name": "Recognized licence is in SPDX format.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 3,
          "metric_test_status": "pass"
        }
      },
      "test_status": "pass",
      "score": {
        "earned": 2,
        "total": 3
      },
      "maturity": 3,
      "output": [
        {
          "license": "MIT License",
          "osi_approved": true,
          "details_url": "http://spdx.org/licenses/MIT.html"
        }
      ],
      "test_debug": [
        "INFO: License verification name through SPDX registry -: MIT License",
        "INFO: Found SPDX license representation -: http://spdx.org/licenses/MIT.json",
        "SUCCESS: Found SPDX license representation (spdx url, osi_approved)",
        "SUCCESS: Found licence file: ['LICENSE.txt'].",
        "INFO: Will consider all SPDX licenses as community specific licenses for FRSM-15-R1.1",
        "WARNING: Test for license information of bundled components is not implemented (FRSM-15-R1.1-2)."
      ]
    },
    {
      "id": 16,
      "metric_identifier": "FRSM-16-R1.1",
      "metric_name": "Does the software metadata record include licensing information?",
      "metric_tests": {
        "FRSM-16-R1.1-1": {
          "metric_test_name": "The identifier or metadata record includes licensing and copyright information.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 1,
          "metric_test_status": "pass"
        },
        "FRSM-16-R1.1-2": {
          "metric_test_name": "The software licensing information is in SPDX format, or other machine-readable form.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 1,
            "total": 1
          },
          "metric_test_maturity": 3,
          "metric_test_status": "pass"
        }
      },
      "test_status": "pass",
      "score": {
        "earned": 2,
        "total": 2
      },
      "maturity": 3,
      "output": [
        {
          "license": "MIT License",
          "osi_approved": true,
          "details_url": "http://spdx.org/licenses/MIT.html"
        }
      ],
      "test_debug": [
        "INFO: License verification name through SPDX registry -: MIT License",
        "INFO: Found SPDX license representation -: http://spdx.org/licenses/MIT.json",
        "SUCCESS: Found SPDX license representation (spdx url, osi_approved)",
        "SUCCESS: Found licence information in metadata",
        "INFO: Will consider all SPDX licenses as community specific licenses for FRSM-16-R1.1"
      ]
    },
    {
      "id": 17,
      "metric_identifier": "FRSM-17-R1.2",
      "metric_name": "Does the software include provenance information that describe the development of the software?",
      "metric_tests": {
        "FRSM-17-R1.2-1": {
          "metric_test_name": "The software source code repository / forge includes a commit history.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-17-R1.2-2": {
          "metric_test_name": "The software source code repository links commits to issues / tickets.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        },
        "FRSM-17-R1.2-3": {
          "metric_test_name": "The software project uses other tools to capture detailed machine readable provenance information.",
          "metric_test_requirements": [],
          "metric_test_score": {
            "earned": 0,
            "total": 1
          },
          "metric_test_maturity": 0,
          "metric_test_status": "fail"
        }
      },
      "test_status": "fail",
      "score": {
        "earned": 0,
        "total": 3
      },
      "maturity": 0,
      "output": {},
      "test_debug": [
        "WARNING: Test for commit history is not implemented.",
        "WARNING: Test for commit linkage to issues is not implemented.",
        "WARNING: Test for other tools capturing provenance information is not implemented."
      ]
    }
  ]
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):